### PR TITLE
API to add members manually & to get admin groups

### DIFF
--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -5,8 +5,9 @@ import {
     Get,
     Headers,
     Param,
+    Patch,
     Post,
-    Put,
+    Query,
     Req,
     UseGuards
 } from "@nestjs/common"
@@ -24,7 +25,7 @@ export class GroupsController {
     constructor(private readonly groupsService: GroupsService) {}
 
     @Get()
-    async getGroups(@Param("adminId") adminId: string) {
+    async getGroups(@Query("adminId") adminId: string) {
         const groups = await this.groupsService.getGroups({ adminId })
 
         return groups.map((g) => mapGroupToResponseDTO(g))
@@ -54,7 +55,7 @@ export class GroupsController {
         )
     }
 
-    @Put(":id")
+    @Patch(":id")
     @UseGuards(AuthGuard)
     async updateGroup(
         @Req() req: Request,

--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -121,7 +121,11 @@ export class GroupsController {
         }
 
         if (dto.id) {
-            await this.groupsService.addMemberManually(groupId, dto.id, req.session.adminId)
+            await this.groupsService.addMemberManually(
+                groupId,
+                dto.id,
+                req.session.adminId
+            )
             return
         }
 

--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -108,7 +108,8 @@ export class GroupsController {
     async addMember(
         @Param("id") groupId: string,
         @Body() dto: AddMemberDto,
-        @Headers() headers: Headers
+        @Headers() headers: Headers,
+        @Req() req: Request
     ): Promise<void> {
         if (dto.inviteCode) {
             await this.groupsService.joinGroup(groupId, dto.id, {
@@ -129,7 +130,10 @@ export class GroupsController {
             return
         }
 
-        // TODO: Implement admin adding members manually
+        if (dto.id) {
+            await this.groupsService.addMemberManually(groupId, dto.id, req.session.adminId)
+            return
+        }
 
         throw new Error("Not implemented")
     }

--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -24,18 +24,8 @@ export class GroupsController {
     constructor(private readonly groupsService: GroupsService) {}
 
     @Get()
-    async getAllGroups() {
-        const groups = await this.groupsService.getAllGroups()
-
-        return groups.map((g) => mapGroupToResponseDTO(g))
-    }
-
-    @Get("admin-groups")
-    @UseGuards(AuthGuard)
-    async getGroupsByAdmin(@Req() req: Request) {
-        const groups = await this.groupsService.getGroupsByAdmin(
-            req.session.adminId
-        )
+    async getAllGroups(@Param("adminId") adminId: string) {
+        const groups = await this.groupsService.getAllGroups({ adminId })
 
         return groups.map((g) => mapGroupToResponseDTO(g))
     }

--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -24,8 +24,8 @@ export class GroupsController {
     constructor(private readonly groupsService: GroupsService) {}
 
     @Get()
-    async getAllGroups(@Param("adminId") adminId: string) {
-        const groups = await this.groupsService.getAllGroups({ adminId })
+    async getGroups(@Param("adminId") adminId: string) {
+        const groups = await this.groupsService.getGroups({ adminId })
 
         return groups.map((g) => mapGroupToResponseDTO(g))
     }

--- a/apps/api/src/app/groups/groups.service.test.ts
+++ b/apps/api/src/app/groups/groups.service.test.ts
@@ -104,11 +104,9 @@ describe("GroupsService", () => {
 
             expect(result).toHaveLength(2)
         })
-    })
 
-    describe("# getGroupsByAdmin", () => {
         it("Should return a list of groups by admin", async () => {
-            const result = await groupsService.getGroupsByAdmin("admin")
+            const result = await groupsService.getAllGroups({ adminId: "admin" })
 
             expect(result).toHaveLength(2)
         })

--- a/apps/api/src/app/groups/groups.service.test.ts
+++ b/apps/api/src/app/groups/groups.service.test.ts
@@ -357,6 +357,43 @@ describe("GroupsService", () => {
         })
     })
 
+    describe("# Add and remove member manually", () => {
+        let group: Group
+
+        beforeAll(async () => {
+            group = await groupsService.createGroup(
+                {
+                    name: "Group2",
+                    description: "This is a new group",
+                    treeDepth: 16
+                },
+                "admin"
+            )
+        })
+
+        it("Should add a member to an existing group manually", async () => {
+            const { members } = await groupsService.addMemberManually(
+                group.id,
+                "123123",
+                "admin"
+            )
+
+            expect(members).toHaveLength(1)
+        })
+
+        it("Should delete a member from an existing group manually", async () => {
+            await groupsService.addMemberManually(group.id, "100001", "admin")
+
+            const { members } = await groupsService.removeMember(
+                group.id,
+                "100001",
+                "admin"
+            )
+
+            expect(members.map((m) => m.id)).not.toContain("100001")
+        })
+    })
+
     describe("# Reputation Criteria", () => {
         it("Should save the reputation criteria for the group", async () => {
             const group = await groupsService.createGroup(

--- a/apps/api/src/app/groups/groups.service.test.ts
+++ b/apps/api/src/app/groups/groups.service.test.ts
@@ -100,17 +100,36 @@ describe("GroupsService", () => {
 
     describe("# getAllGroupsData", () => {
         it("Should return a list of groups", async () => {
-            const result = await groupsService.getAllGroups()
+            const result = await groupsService.getGroups()
 
             expect(result).toHaveLength(2)
         })
 
         it("Should return a list of groups by admin", async () => {
-            const result = await groupsService.getAllGroups({
-                adminId: "admin"
+            await groupsService.createGroup(
+                {
+                    name: "Group01",
+                    description: "This is a description",
+                    treeDepth: 16
+                },
+                "admin01"
+            )
+
+            // Create a group with another adminId - shouldn't be fetched below
+            await groupsService.createGroup(
+                {
+                    name: "Group02",
+                    description: "This is a description",
+                    treeDepth: 16
+                },
+                "admin02"
+            )
+
+            const result = await groupsService.getGroups({
+                adminId: "admin01"
             })
 
-            expect(result).toHaveLength(2)
+            expect(result).toHaveLength(1)
         })
     })
 

--- a/apps/api/src/app/groups/groups.service.test.ts
+++ b/apps/api/src/app/groups/groups.service.test.ts
@@ -106,7 +106,9 @@ describe("GroupsService", () => {
         })
 
         it("Should return a list of groups by admin", async () => {
-            const result = await groupsService.getAllGroups({ adminId: "admin" })
+            const result = await groupsService.getAllGroups({
+                adminId: "admin"
+            })
 
             expect(result).toHaveLength(2)
         })

--- a/apps/api/src/app/groups/groups.service.ts
+++ b/apps/api/src/app/groups/groups.service.ts
@@ -363,7 +363,7 @@ export class GroupsService {
      * Returns a list of groups.
      * @returns List of existing groups.
      */
-    async getAllGroups(filters?: { adminId: string }): Promise<Group[]> {
+    async getGroups(filters?: { adminId: string }): Promise<Group[]> {
         const where = []
 
         if (filters?.adminId) {
@@ -371,7 +371,8 @@ export class GroupsService {
         }
 
         return this.groupRepository.find({
-            relations: { members: true }
+            relations: { members: true },
+            where
         })
     }
 
@@ -427,7 +428,7 @@ export class GroupsService {
     }
 
     private async _cacheGroups() {
-        const groups = await this.getAllGroups()
+        const groups = await this.getGroups()
 
         /* istanbul ignore next */
         for (const group of groups) {

--- a/apps/api/src/app/groups/groups.service.ts
+++ b/apps/api/src/app/groups/groups.service.ts
@@ -364,7 +364,7 @@ export class GroupsService {
      * @returns List of existing groups.
      */
     async getAllGroups(filters?: { adminId: string }): Promise<Group[]> {
-        const where = [];
+        const where = []
 
         if (filters?.adminId) {
             where.push({ adminId: filters.adminId })
@@ -374,7 +374,6 @@ export class GroupsService {
             relations: { members: true }
         })
     }
-
 
     /**
      * Returns a specific group.

--- a/apps/api/src/app/groups/groups.service.ts
+++ b/apps/api/src/app/groups/groups.service.ts
@@ -194,7 +194,7 @@ export class GroupsService {
     ): Promise<Group> {
         const group = await this.getGroup(groupId)
 
-        if (group.admin !== adminId) {
+        if (group.adminId !== adminId) {
             throw new UnauthorizedException(
                 `You are not the admin of the group '${groupId}'`
             )
@@ -363,23 +363,18 @@ export class GroupsService {
      * Returns a list of groups.
      * @returns List of existing groups.
      */
-    async getAllGroups(): Promise<Group[]> {
+    async getAllGroups(filters?: { adminId: string }): Promise<Group[]> {
+        const where = [];
+
+        if (filters?.adminId) {
+            where.push({ adminId: filters.adminId })
+        }
+
         return this.groupRepository.find({
             relations: { members: true }
         })
     }
 
-    /**
-     * Returns a list of groups of a specific admin.
-     * @param admin Admin id.
-     * @returns List of admin's existing groups.
-     */
-    async getGroupsByAdmin(admin: string): Promise<Group[]> {
-        return this.groupRepository.find({
-            relations: { members: true },
-            where: { adminId: admin }
-        })
-    }
 
     /**
      * Returns a specific group.

--- a/apps/dashboard/src/api/bandadaAPI.ts
+++ b/apps/dashboard/src/api/bandadaAPI.ts
@@ -86,7 +86,7 @@ export async function updateGroup(
 ) {
     try {
         return (await request(`${API_URL}/groups/${groupId}`, {
-            method: "PUT",
+            method: "PATCH",
             data: { apiEnabled }
         })) as Group
     } catch (error) {

--- a/apps/dashboard/src/api/bandadaAPI.ts
+++ b/apps/dashboard/src/api/bandadaAPI.ts
@@ -24,9 +24,9 @@ export async function generateMagicLink(
     }
 }
 
-export async function getGroups(): Promise<Group[] | null> {
+export async function getGroups(adminId: string): Promise<Group[] | null> {
     try {
-        return await request(`${API_URL}/groups/admin-groups`)
+        return await request(`${API_URL}/groups/?adminId=${adminId}`)
     } catch (error) {
         console.error(error)
 

--- a/apps/dashboard/src/components/navbar.tsx
+++ b/apps/dashboard/src/components/navbar.tsx
@@ -23,7 +23,10 @@ export default function NavBar(): JSX.Element {
         [chain]
     )
 
-    const isLoggedInAdmin = useCallback(() => getAdmin() === address, [address])
+    const isLoggedInAdmin = useCallback(
+        () => getAdmin()?.address === address,
+        [address]
+    )
 
     useEffect(() => {
         if (getAdmin() && !isLoggedInAdmin()) {

--- a/apps/dashboard/src/context/auth-context.tsx
+++ b/apps/dashboard/src/context/auth-context.tsx
@@ -47,6 +47,8 @@ const wagmiClient = createClient({
 const customTheme = lightTheme()
 customTheme.radii.modal = "10px"
 
+export const AuthContext = React.createContext({ getAdmin })
+
 export function AuthContextProvider(props: { children: ReactNode }) {
     const { children } = props
 
@@ -88,7 +90,7 @@ export function AuthContextProvider(props: { children: ReactNode }) {
 
                     if (user) {
                         setAuthStatus("authenticated")
-                        saveAdmin(user.address)
+                        saveAdmin(user)
 
                         window.location.reload()
 
@@ -114,23 +116,26 @@ export function AuthContextProvider(props: { children: ReactNode }) {
     )
 
     return (
-        <WagmiConfig client={wagmiClient}>
-            <RainbowKitAuthenticationProvider
-                adapter={authAdapter}
-                status={authStatus}
-            >
-                <RainbowKitProvider
-                    chains={chains}
-                    modalSize="compact"
-                    theme={customTheme}
-                    appInfo={{
-                        appName: "Bandada"
-                    }}
-                    showRecentTransactions={false}
+        // eslint-disable-next-line react/jsx-no-constructed-context-values
+        <AuthContext.Provider value={{ getAdmin }}>
+            <WagmiConfig client={wagmiClient}>
+                <RainbowKitAuthenticationProvider
+                    adapter={authAdapter}
+                    status={authStatus}
                 >
-                    {children}
-                </RainbowKitProvider>
-            </RainbowKitAuthenticationProvider>
-        </WagmiConfig>
+                    <RainbowKitProvider
+                        chains={chains}
+                        modalSize="compact"
+                        theme={customTheme}
+                        appInfo={{
+                            appName: "Bandada"
+                        }}
+                        showRecentTransactions={false}
+                    >
+                        {children}
+                    </RainbowKitProvider>
+                </RainbowKitAuthenticationProvider>
+            </WagmiConfig>
+        </AuthContext.Provider>
     )
 }

--- a/apps/dashboard/src/pages/groups.tsx
+++ b/apps/dashboard/src/pages/groups.tsx
@@ -10,7 +10,7 @@ import {
     Select,
     useDisclosure
 } from "@chakra-ui/react"
-import { useEffect, useState } from "react"
+import { useContext, useEffect, useState } from "react"
 import { FiSearch } from "react-icons/fi"
 import { useAccount } from "wagmi"
 import { getGroups as getOffchainGroups } from "../api/bandadaAPI"
@@ -18,9 +18,11 @@ import { getGroups as getOnchainGroups } from "../api/semaphoreAPI"
 import CreateGroupModal from "../components/create-group-modal"
 import GroupBox from "../components/group-box"
 import { Group } from "../types/groups"
+import { AuthContext } from "../context/auth-context"
 
 export default function GroupsPage(): JSX.Element {
     const { address } = useAccount()
+    const { getAdmin } = useContext(AuthContext)
     const { isOpen, onOpen, onClose } = useDisclosure()
     const [isLoading, setIsLoading] = useState(false)
     const [_groupList, setGroupList] = useState<Group[] | null>()
@@ -33,7 +35,9 @@ export default function GroupsPage(): JSX.Element {
                 setIsLoading(true)
 
                 const onchainGroups = await getOnchainGroups(address as string)
-                const offchainGroups = await getOffchainGroups()
+                const offchainGroups = await getOffchainGroups(
+                    getAdmin()?.id as string
+                )
 
                 if (onchainGroups && offchainGroups) {
                     setGroupList([
@@ -51,6 +55,7 @@ export default function GroupsPage(): JSX.Element {
                 setIsLoading(false)
             }
         })()
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [address])
 
     useEffect(() => {

--- a/apps/dashboard/src/utils/session.ts
+++ b/apps/dashboard/src/utils/session.ts
@@ -3,12 +3,16 @@
 // to store admins' sessions manually.
 // TODO: explore other solutions.
 
-export function saveAdmin(address: string) {
-    localStorage.setItem("admin", address)
+export function saveAdmin(admin: { address: string; id: string }) {
+    localStorage.setItem("admin", JSON.stringify(admin))
 }
 
 export function getAdmin() {
-    return localStorage.getItem("admin")
+    const admin = localStorage.getItem("admin")
+    if (admin) {
+        return JSON.parse(admin)
+    }
+    return null
 }
 
 export function deleteAdmin() {


### PR DESCRIPTION
## Description

- Add API to add members manually
- Remove `/admin-groups` API and add `adminId` query param to `/groups`
- Update dashboard to new `/groups` to fetch admin groups

## Related Issue

#195 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

