### PR TITLE
Update addMemberByReputation route

### DIFF
--- a/apps/api/src/app/reputation/reputation.controller.ts
+++ b/apps/api/src/app/reputation/reputation.controller.ts
@@ -12,7 +12,7 @@ export class ReputationController {
         return this.reputationService.setOAuthState(dto)
     }
 
-    @Post("add-member")
+    @Post()
     async addMemberByReputation(
         @Body() dto: AddMemberDto
     ): Promise<void | any> {


### PR DESCRIPTION
## Related Issue

#217 

## Does this introduce a breaking change?

-   [x] Yes
-   [ ] No

The old route to add a member by reputation is `/reputation/add-member`. The new route is `/reputation`.
