### PR TITLE
Add Waiter services stable in a loop

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -7,4 +7,8 @@ for task in $tasks; do
   aws ecs update-service --cluster bandada --service $task --force-new-deployment --task-definition $task:$bandada_revision
 done
 
-aws ecs wait services-stable --cluster bandada --services $tasks
+for loop in {1..2}; do
+  aws ecs wait services-stable --cluster bandada --services $tasks && break || continue
+done
+
+exit 0


### PR DESCRIPTION
## Description
When ECR deployment takes more than 10', waiter **services-stable** that is responsible to confirm that the task in question enters a RUNNING state, fails with a **max attempts exceeded** error message.
It polls every 15" until a successful state has been reached and exits with a return code of 255 after 40 failed checks. It seems there is no way to adjust these thresholds, so the workaround is to add the aws cli command in a loop. The timeout was increased from 10' -> 20'. 

## Related Issue
https://github.com/privacy-scaling-explorations/bandada/actions/runs/5678904600/job/15390041918

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
