### PR TITLE
chore: remove primary index from members table

### DIFF
--- a/apps/api/src/app/groups/entities/member.entity.ts
+++ b/apps/api/src/app/groups/entities/member.entity.ts
@@ -14,7 +14,7 @@ import { Group } from "./group.entity"
 @Unique(["id", "group"])
 @Index(["id", "group"])
 export class Member {
-    @Column({ primary: true, unique: false })
+    @Column()
     id: string
 
     // In reality the relation group -> members is many-to-many.

--- a/database/seed.sql
+++ b/database/seed.sql
@@ -26,7 +26,7 @@ CREATE TABLE groups (
 -- Table Definition ----------------------------------------------
 
 CREATE TABLE members (
-    id character varying PRIMARY KEY,
+    id character varying NOT NULL,
     created_at timestamp without time zone NOT NULL DEFAULT now(),
     group_id character varying(32) REFERENCES groups(id),
     CONSTRAINT "UQ_db97b66d973228a2049c76f89e2" UNIQUE (id, group_id)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a bug which was not allowing the app to have the same member ID in more than 1 group.

## Related Issue

#265

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
