### PR TITLE
fixes #287 : error message when incorrect network 

### DIFF
--- a/apps/dashboard/src/components/add-member-modal.tsx
+++ b/apps/dashboard/src/components/add-member-modal.tsx
@@ -98,7 +98,7 @@ export default function AddMemberModal({
                 setIsLoading(false)
                 onClose(_memberId)
             } catch (error) {
-                alert("Switch to Goerli network!")
+                alert("Wrong network! Switch to Goerli!")
 
                 setIsLoading(false)
             }

--- a/apps/dashboard/src/components/add-member-modal.tsx
+++ b/apps/dashboard/src/components/add-member-modal.tsx
@@ -98,7 +98,7 @@ export default function AddMemberModal({
                 setIsLoading(false)
                 onClose(_memberId)
             } catch (error) {
-                alert("Some error occurred!")
+                alert("Switch to Goerli network!")
 
                 setIsLoading(false)
             }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

Substituted the string for the error message in `add-member-modal.tsx` such that users will be prompted to act accordingly instead of a general `"Some error occurred"` message.

File path: `apps > dashboard > src > components > .txs`

## Related Issue

[Link to the issue](https://github.com/privacy-scaling-explorations/bandada/issues/287)

## Does this introduce a breaking change?
No
