### PR TITLE
Add the `x-api-key` parameter as required in the API Docs.

### DIFF
--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -189,7 +189,7 @@ export class GroupsController {
 
     @Post(":group/members")
     @ApiBody({ type: AddMembersDto })
-    @ApiHeader({ name: "x-api-key", required: false })
+    @ApiHeader({ name: "x-api-key", required: true })
     @ApiOperation({
         description:
             "Adds multiple members to a group. Requires either API Key in the headers or a valid session."


### PR DESCRIPTION
Add the `x-api-key` parameter as required in `addMembers` in the API Docs.

Closes #309