### PR TITLE
Add Many-to-Many relationship between Group and Member

### DIFF
--- a/apps/api/src/app/credentials/credentials.service.test.ts
+++ b/apps/api/src/app/credentials/credentials.service.test.ts
@@ -162,9 +162,15 @@ describe("CredentialsService", () => {
         })
 
         it("Should add a member to a credential group", async () => {
+            const _stateId = await credentialsService.setOAuthState({
+                groupId,
+                memberId: "125",
+                providerName: "twitter"
+            })
+
             const clientRedirectUri = await credentialsService.addMember(
                 "code",
-                stateId
+                _stateId
             )
 
             expect(clientRedirectUri).toBeUndefined()

--- a/apps/api/src/app/groups/entities/group.entity.ts
+++ b/apps/api/src/app/groups/entities/group.entity.ts
@@ -3,6 +3,8 @@ import {
     CreateDateColumn,
     Entity,
     Index,
+    JoinTable,
+    ManyToMany,
     OneToMany,
     PrimaryColumn,
     UpdateDateColumn
@@ -31,8 +33,17 @@ export class Group {
     @Column({ name: "fingerprint_duration" })
     fingerprintDuration: number
 
-    @OneToMany(() => Member, (member) => member.group, {
-        cascade: ["insert"]
+    @ManyToMany(() => Member)
+    @JoinTable({
+        name: "memberships",
+        joinColumn: {
+            name: "group",
+            referencedColumnName: "id"
+        },
+        inverseJoinColumn: {
+            name: "member",
+            referencedColumnName: "id"
+        }
     })
     members: Member[]
 

--- a/apps/api/src/app/groups/entities/member.entity.ts
+++ b/apps/api/src/app/groups/entities/member.entity.ts
@@ -1,31 +1,10 @@
-import {
-    CreateDateColumn,
-    Entity,
-    ManyToOne,
-    Column,
-    Index,
-    Unique,
-    JoinColumn
-} from "typeorm"
-
-import { Group } from "./group.entity"
+import { CreateDateColumn, Entity, Index, PrimaryColumn } from "typeorm"
 
 @Entity("members")
-@Unique(["id", "group"])
-@Index(["id", "group"])
 export class Member {
-    @Column({ primary: true, unique: false })
+    @PrimaryColumn()
+    @Index({ unique: true })
     id: string
-
-    // In reality the relation group -> members is many-to-many.
-    // i.e we allow same member id to be part of many groups.
-    // But since this property is not used in any feature at the moment,
-    // it is treated as many-to-one in the code for simplicity.
-    @ManyToOne(() => Group, (group) => group.members, {
-        onDelete: "CASCADE"
-    })
-    @JoinColumn({ name: "group_id" })
-    group: Group
 
     @CreateDateColumn({ name: "created_at" })
     createdAt: Date


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces a Many-to-Many relationship between Group and Member (a Group can contain multiple Members and a Member can join one or more Groups). The relationship is unidirectional and maintained in the Group. This allows for a join table between Group and Member that does not affect the current APIs, introducing an externally imperceptible (non-breaking) change. This approach was chosen because the join table did not require additional information beyond the Group and Member identifiers having a relationship, denoted by the term `Membership`.

## Related Issue
- fix #265 
- complete https://github.com/privacy-scaling-explorations/bandada/pull/267
 
## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No


