### PR TITLE
Add a missing test case to check if the same credential with different identities can join different groups

### DIFF
--- a/apps/api/src/app/credentials/credentials.service.test.ts
+++ b/apps/api/src/app/credentials/credentials.service.test.ts
@@ -93,7 +93,7 @@ describe("CredentialsService", () => {
             const fun = credentialsService.setOAuthState({
                 groupId: _groupId,
                 memberId: "123",
-                providerName: "twitter"
+                providerName: "github"
             })
 
             await expect(fun).rejects.toThrow(
@@ -117,7 +117,7 @@ describe("CredentialsService", () => {
             stateId = await credentialsService.setOAuthState({
                 groupId,
                 memberId: "123",
-                providerName: "twitter"
+                providerName: "github"
             })
 
             expect(stateId).toHaveLength(36)
@@ -129,7 +129,7 @@ describe("CredentialsService", () => {
                     ({
                         getAccessToken: jest.fn(() => "123"),
                         getProfile: jest.fn(() => ({
-                            id: "id2"
+                            id: "id1"
                         }))
                     } as any)
             )
@@ -137,7 +137,7 @@ describe("CredentialsService", () => {
             const _stateId = await credentialsService.setOAuthState({
                 groupId,
                 memberId: "123",
-                providerName: "twitter"
+                providerName: "github"
             })
 
             await credentialsService.addMember("code", _stateId)
@@ -145,7 +145,7 @@ describe("CredentialsService", () => {
             const fun = credentialsService.setOAuthState({
                 groupId,
                 memberId: "123",
-                providerName: "twitter"
+                providerName: "github"
             })
 
             await expect(fun).rejects.toThrow(
@@ -164,8 +164,8 @@ describe("CredentialsService", () => {
         it("Should add a member to a credential group", async () => {
             const _stateId = await credentialsService.setOAuthState({
                 groupId,
-                memberId: "125",
-                providerName: "twitter"
+                memberId: "124",
+                providerName: "github"
             })
 
             const clientRedirectUri = await credentialsService.addMember(
@@ -176,18 +176,58 @@ describe("CredentialsService", () => {
             expect(clientRedirectUri).toBeUndefined()
         })
 
-        it("Should throw an error if the same OAuth account tries to join the same group", async () => {
-            const _stateId = await credentialsService.setOAuthState({
+        it("Should add the same credential with different identities in different groups", async () => {
+            const { id: _groupId } = await groupsService.createGroup(
+                {
+                    name: "Group2",
+                    description: "This is a description",
+                    treeDepth: 16,
+                    fingerprintDuration: 3600,
+                    credentials: JSON.stringify({
+                        id: "GITHUB_FOLLOWERS",
+                        criteria: {
+                            minFollowers: 12
+                        }
+                    })
+                },
+                "admin"
+            )
+
+            const _stateId1 = await credentialsService.setOAuthState({
                 groupId,
-                memberId: "124",
-                providerName: "twitter"
+                memberId: "125",
+                providerName: "github"
             })
 
-            const fun = credentialsService.addMember("code", _stateId)
+            const _stateId2 = await credentialsService.setOAuthState({
+                groupId: _groupId,
+                memberId: "126",
+                providerName: "github"
+            })
 
-            await expect(fun).rejects.toThrow(
-                `OAuth account has already joined the group`
+            ;(getProvider as any).mockImplementationOnce(
+                () =>
+                    ({
+                        getAccessToken: jest.fn(() => "123"),
+                        getProfile: jest.fn(() => ({
+                            id: "id2" // same OAuth account.
+                        }))
+                    } as any)
             )
+
+            const clientRedirectUri1 = await credentialsService.addMember(
+                "code",
+                _stateId1
+            )
+
+            expect(clientRedirectUri1).toBeUndefined()
+
+            const clientRedirectUri2 = await credentialsService.addMember(
+                "code",
+                _stateId2
+            )
+
+            expect(clientRedirectUri2).toBeUndefined()
         })
 
         it("Should throw an error if the OAuth account does not have enough credential", async () => {
@@ -206,14 +246,38 @@ describe("CredentialsService", () => {
 
             const _stateId = await credentialsService.setOAuthState({
                 groupId,
-                memberId: "124",
-                providerName: "twitter"
+                memberId: "127",
+                providerName: "github"
             })
 
             const fun = credentialsService.addMember("code", _stateId)
 
             await expect(fun).rejects.toThrow(
                 `OAuth account does not match criteria`
+            )
+        })
+
+        it("Should throw an error if the same OAuth account tries to join the same group", async () => {
+            ;(getProvider as any).mockImplementationOnce(
+                () =>
+                    ({
+                        getAccessToken: jest.fn(() => "123"),
+                        getProfile: jest.fn(() => ({
+                            id: "id2" // OAuth account already used to join the group.
+                        }))
+                    } as any)
+            )
+
+            const _stateId = await credentialsService.setOAuthState({
+                groupId,
+                memberId: "128",
+                providerName: "github"
+            })
+
+            const fun = credentialsService.addMember("code", _stateId)
+
+            await expect(fun).rejects.toThrow(
+                `OAuth account has already joined the group`
             )
         })
     })


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a test case to the credential service to verify that the same credential (same OAuth account) can be associated with different identities at the same time, and that each of them can join a different group.

<!--- Describe your changes in detail -->

- Added missing test case
- Changed the provider from `twitter` to `github` as we are `GITHUB_FOLLOWERS` as credentials.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #305 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Depends on #325

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
