### PR TITLE
Wrong initialization of cached groups in Group service

### DIFF
--- a/apps/api/src/app/groups/groups.service.test.ts
+++ b/apps/api/src/app/groups/groups.service.test.ts
@@ -44,6 +44,8 @@ describe("GroupsService", () => {
         }).compile()
 
         groupsService = await module.resolve(GroupsService)
+        await groupsService.initialize()
+
         invitesService = await module.resolve(InvitesService)
 
         const { id } = await groupsService.createGroup(
@@ -721,6 +723,19 @@ describe("GroupsService", () => {
             )
 
             await expect(fun).rejects.toThrow("You are not the admin")
+        })
+    })
+
+    describe("# initialize", () => {
+        it("Should initialize the cached groups", async () => {
+            const currentCachedGroups = await groupsService.getGroups()
+
+            await groupsService.initialize()
+
+            const updatedCachedGroups = await groupsService.getGroups()
+
+            expect(currentCachedGroups).toHaveLength(updatedCachedGroups.length)
+            expect(currentCachedGroups).toStrictEqual(updatedCachedGroups)
         })
     })
 })

--- a/apps/api/src/app/groups/groups.service.ts
+++ b/apps/api/src/app/groups/groups.service.ts
@@ -39,13 +39,19 @@ export class GroupsService {
             process.env.BACKEND_PRIVATE_KEY as string,
             process.env.INFURA_API_KEY as string
         )
+    }
 
-        this._cacheGroups()
+    /**
+     * Initialises the service, caches groups and may sync contract
+     * groups if required.
+     */
+    async initialize() {
+        await this._cacheGroups()
 
         /* istanbul ignore next */
         if (process.env.NODE_ENV !== "test") {
-            setTimeout(() => {
-                this._syncContractGroups()
+            setTimeout(async () => {
+                await this._syncContractGroups()
             }, 5000)
         }
     }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -3,9 +3,13 @@ import { NestFactory } from "@nestjs/core"
 import { SwaggerModule, DocumentBuilder } from "@nestjs/swagger"
 import { ironSession } from "iron-session/express"
 import { AppModule } from "./app/app.module"
+import { GroupsService } from "./app/groups/groups.service"
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule)
+
+    const groupService = app.get(GroupsService)
+    await groupService.initialize()
 
     app.useGlobalPipes(
         new ValidationPipe({


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
See #303 

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

See #303 

## Does this introduce a breaking change?

-   [x] Yes
-   [ ] No

We are making a small alteration to the GroupService initialization process. Previously, we erroneously performed the `cachedGroups` initialization in the constructor. We have now introduced a dedicated method, `initialize()`, which must be called immediately after creating the GroupService object.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
