### PR TITLE
Enable ECS staging deployment 

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -2,21 +2,23 @@
 set -ex
 
 build=$1
+env=""
 
 [ $build = "enable" ] || exit 0
+[ "$2" = "prod" ] || { env="-$2"; sed -i 's/production/staging/' apps/client/package.json apps/dashboard/package.json; }
 
 aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin 490752553772.dkr.ecr.eu-central-1.amazonaws.com
 
-docker build -t bandada-api:latest -f apps/api/Dockerfile .
-docker tag bandada-api:latest 490752553772.dkr.ecr.eu-central-1.amazonaws.com/bandada-api:latest
-docker push 490752553772.dkr.ecr.eu-central-1.amazonaws.com/bandada-api:latest
+docker build -t bandada-api$env:latest -f apps/api/Dockerfile .
+docker tag bandada-api$env:latest 490752553772.dkr.ecr.eu-central-1.amazonaws.com/bandada-api$env:latest
+docker push 490752553772.dkr.ecr.eu-central-1.amazonaws.com/bandada-api$env:latest
 
-docker build -t bandada-client:latest -f apps/client/Dockerfile .
-docker tag bandada-client:latest 490752553772.dkr.ecr.eu-central-1.amazonaws.com/bandada-client:latest
-docker push 490752553772.dkr.ecr.eu-central-1.amazonaws.com/bandada-client:latest
+docker build -t bandada-client$env:latest -f apps/client/Dockerfile .
+docker tag bandada-client$env:latest 490752553772.dkr.ecr.eu-central-1.amazonaws.com/bandada-client$env:latest
+docker push 490752553772.dkr.ecr.eu-central-1.amazonaws.com/bandada-client$env:latest
 
-docker build -t bandada-dashboard:latest -f apps/dashboard/Dockerfile .
-docker tag bandada-dashboard:latest 490752553772.dkr.ecr.eu-central-1.amazonaws.com/bandada-dashboard:latest
-docker push 490752553772.dkr.ecr.eu-central-1.amazonaws.com/bandada-dashboard:latest
+docker build -t bandada-dashboard$env:latest -f apps/dashboard/Dockerfile .
+docker tag bandada-dashboard$env:latest 490752553772.dkr.ecr.eu-central-1.amazonaws.com/bandada-dashboard$env:latest
+docker push 490752553772.dkr.ecr.eu-central-1.amazonaws.com/bandada-dashboard$env:latest
 
 exit 0

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 set -ex
+
+env=""
+
+[ "$1" = "prod" ] || env="-$1"
  
-tasks="bandada-client bandada-api bandada-dashboard"
+tasks="bandada-client$env bandada-api$env bandada-dashboard$env"
 for task in $tasks; do
   bandada_revision=$(aws ecs describe-task-definition --task-definition $task --query "taskDefinition.revision")
-  aws ecs update-service --cluster bandada --service $task --force-new-deployment --task-definition $task:$bandada_revision
+  aws ecs update-service --cluster bandada$env --service $task --force-new-deployment --task-definition $task:$bandada_revision
 done
 
-for loop in {1..2}; do
-  aws ecs wait services-stable --cluster bandada --services $tasks && break || continue
+for loop in {1..3}; do
+  [ "$loop" -eq 3 ] && exit 1
+  aws ecs wait services-stable --cluster bandada$env --services $tasks && break || continue
 done
-
-exit 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,9 +13,9 @@ on:
                     - enable
                     - disable
             environment:
-                description: 'Environment'
+                description: "Environment"
                 required: true
-                default: 'prod'
+                default: "prod"
                 type: choice
                 options:
                     - prod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,14 @@ on:
                 options:
                     - enable
                     - disable
+            environment:
+                description: 'Environment'
+                required: true
+                default: 'prod'
+                type: choice
+                options:
+                    - prod
+                    - stg
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,11 +30,21 @@ jobs:
         runs-on: ubuntu-latest
         env:
             DATA: ${{ github.event.inputs.build || 'enable' }}
+            DATA_ENV: ${{ github.event.inputs.environment || 'prod' }}
         permissions:
             id-token: write
             contents: read
 
         steps:
+            - name: Check branch
+              run: |
+                  if [ "${{ env.DATA_ENV }}" = "prod" ]; then
+                    if [ "$GITHUB_REF_NAME" != "main" ]; then
+                      echo "Operation not permitted"
+                      exit 1
+                    fi
+                  fi
+
             - name: Checkout
               uses: actions/checkout@v2
               with:
@@ -41,8 +59,8 @@ jobs:
 
             - name: Build and Push images to ECR
               run: |
-                  .github/scripts/build.sh ${{ env.DATA }}
+                  .github/scripts/build.sh ${{ env.DATA }} ${{ env.DATA_ENV }}
 
             - name: Create Deployment
               run: |
-                  .github/scripts/deploy.sh
+                  .github/scripts/deploy.sh ${{ env.DATA_ENV }}

--- a/apps/client/.env.staging
+++ b/apps/client/.env.staging
@@ -1,0 +1,4 @@
+# This file contains build time variables for staging env.
+
+VITE_API_URL=https://api-staging.bandada.pse.dev
+VITE_DASHBOARD_URL=https://staging.bandada.pse.dev

--- a/apps/dashboard/.env.staging
+++ b/apps/dashboard/.env.staging
@@ -1,0 +1,9 @@
+# This file contains build time variables for staging env.
+
+VITE_API_URL=https://api-staging.bandada.pse.dev
+VITE_CLIENT_URL=https://client-staging.bandada.pse.dev
+VITE_CLIENT_INVITES_URL=https://client-staging.bandada.pse.dev?inviteCode=\
+VITE_ETHEREUM_NETWORK=goerli
+VITE_GITHUB_CLIENT_ID=6ccd7b93e84260e353f9
+VITE_TWITTER_CLIENT_ID=NV82Mm85NWlSZ1llZkpLMl9vN3A6MTpjaQ
+VITE_TWITTER_REDIRECT_URI=https://staging.bandada.pse.dev/credentials


### PR DESCRIPTION
## Description
- Enable staging deployment using deploy GH Actions workflow
- The production environment can only be deployed from the main branch
  
## Does this introduce a breaking change?
-   [ ] Yes
-   [x] No

## Other information
- staging endpoints:
  - staging.bandada.pse.dev
  - api-staging.bandada.pse.dev
  - client-staging.bandada.pse.dev