### PR TITLE
refactoring: lists the off-chain groups based on recent creation

### DIFF
--- a/apps/dashboard/src/pages/groups.tsx
+++ b/apps/dashboard/src/pages/groups.tsx
@@ -37,11 +37,13 @@ export default function GroupsPage(): JSX.Element {
 
                 await Promise.all([
                     getOnchainGroups(admin.address).then((onchainGroups) => {
+                        
                         if (onchainGroups) {
                             setGroups((groups) => [...groups, ...onchainGroups])
                         }
                     }),
                     getOffchainGroups(admin.id).then((offchainGroups) => {
+                        console.log("Offchain Groups Response:", offchainGroups) // Log the response
                         if (offchainGroups) {
                             setGroups((groups) => [
                                 ...groups,
@@ -135,8 +137,8 @@ export default function GroupsPage(): JSX.Element {
                             .filter(filterGroup)
                             .sort(
                                 (a, b) =>
-                                    new Date(b.createdAt).getTime() -
-                                    new Date(a.createdAt).getTime()
+                                    new Date(b.createdAt || "").getTime() - // Convert string to Date object
+                                    new Date(a.createdAt || "").getTime()
                             )
                             .map((group) => (
                                 <Link

--- a/apps/dashboard/src/pages/groups.tsx
+++ b/apps/dashboard/src/pages/groups.tsx
@@ -133,8 +133,10 @@ export default function GroupsPage(): JSX.Element {
                     >
                         {_groups
                             .filter(filterGroup)
-                            .sort((a, b) =>
-                                a.name < b.name ? -1 : a.name > b.name ? 1 : 0
+                            .sort(
+                                (a, b) =>
+                                    new Date(b.createdAt).getTime() -
+                                    new Date(a.createdAt).getTime()
                             )
                             .map((group) => (
                                 <Link

--- a/apps/dashboard/src/pages/groups.tsx
+++ b/apps/dashboard/src/pages/groups.tsx
@@ -37,7 +37,6 @@ export default function GroupsPage(): JSX.Element {
 
                 await Promise.all([
                     getOnchainGroups(admin.address).then((onchainGroups) => {
-                        
                         if (onchainGroups) {
                             setGroups((groups) => [...groups, ...onchainGroups])
                         }

--- a/apps/dashboard/src/pages/groups.tsx
+++ b/apps/dashboard/src/pages/groups.tsx
@@ -42,7 +42,6 @@ export default function GroupsPage(): JSX.Element {
                         }
                     }),
                     getOffchainGroups(admin.id).then((offchainGroups) => {
-                        console.log("Offchain Groups Response:", offchainGroups) // Log the response
                         if (offchainGroups) {
                             setGroups((groups) => [
                                 ...groups,

--- a/apps/dashboard/src/types/Group.ts
+++ b/apps/dashboard/src/types/Group.ts
@@ -10,7 +10,7 @@ export type Group = {
     admin: string
     apiEnabled?: boolean
     apiKey?: string
-    createdAt?: string 
+    createdAt?: string
 }
 
 export type GroupSize = {

--- a/apps/dashboard/src/types/Group.ts
+++ b/apps/dashboard/src/types/Group.ts
@@ -10,6 +10,7 @@ export type Group = {
     admin: string
     apiEnabled?: boolean
     apiKey?: string
+    createdAt?: string 
 }
 
 export type GroupSize = {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

Implementing a refactoring to list off-chain groups based on their creation date. This feature enhances the user experience by allowing users to easily access the most recently created groups.
this resolves issue #344 



## Description
Previously, users had to manually navigate through the list of groups to find the ones they were interested in because the groups were listed in alphabetical order.With this new re-factoring, the groups are displayed in order of their creation date, making it easier for users to find the latest content.


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?


 **No**

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
