### PR TITLE
Update the `GITHUB_REPOSITORY_COMMITS` validator

### DIFF
--- a/apps/api/src/app/credentials/credentials.service.test.ts
+++ b/apps/api/src/app/credentials/credentials.service.test.ts
@@ -143,10 +143,8 @@ describe("CredentialsService", () => {
             })
 
             await credentialsService.addMember(
-                "code",
                 _stateId,
-                undefined,
-                undefined
+                "code"
             )
 
             const fun = credentialsService.setOAuthState({
@@ -164,10 +162,8 @@ describe("CredentialsService", () => {
     describe("# addMember", () => {
         it("Should throw an error if the OAuth does not exist", async () => {
             const fun = credentialsService.addMember(
-                "code",
                 "123",
-                undefined,
-                undefined
+                "code"
             )
 
             await expect(fun).rejects.toThrow(`OAuth state does not exist`)
@@ -181,10 +177,8 @@ describe("CredentialsService", () => {
             })
 
             const clientRedirectUri = await credentialsService.addMember(
-                "code",
                 _stateId,
-                undefined,
-                undefined
+                "code"
             )
 
             expect(clientRedirectUri).toBeUndefined()
@@ -230,19 +224,15 @@ describe("CredentialsService", () => {
             )
 
             const clientRedirectUri1 = await credentialsService.addMember(
-                "code",
                 _stateId1,
-                undefined,
-                undefined
+                "code"
             )
 
             expect(clientRedirectUri1).toBeUndefined()
 
             const clientRedirectUri2 = await credentialsService.addMember(
-                "code",
                 _stateId2,
-                undefined,
-                undefined
+                "code"
             )
 
             expect(clientRedirectUri2).toBeUndefined()
@@ -269,10 +259,8 @@ describe("CredentialsService", () => {
             })
 
             const fun = credentialsService.addMember(
-                "code",
                 _stateId,
-                undefined,
-                undefined
+                "code"
             )
 
             await expect(fun).rejects.toThrow(
@@ -298,10 +286,8 @@ describe("CredentialsService", () => {
             })
 
             const fun = credentialsService.addMember(
-                "code",
                 _stateId,
-                undefined,
-                undefined
+                "code"
             )
 
             await expect(fun).rejects.toThrow(
@@ -335,8 +321,8 @@ describe("CredentialsService", () => {
             })
 
             const clientRedirectUri = await credentialsService.addMember(
-                "",
                 _stateId,
+                undefined,
                 "0x",
                 "sepolia"
             )
@@ -352,8 +338,8 @@ describe("CredentialsService", () => {
             })
 
             const clientRedirectUri = await credentialsService.addMember(
-                "",
                 _stateId,
+                undefined,
                 "0x1",
                 "sepolia",
                 "1234"

--- a/apps/api/src/app/credentials/credentials.service.test.ts
+++ b/apps/api/src/app/credentials/credentials.service.test.ts
@@ -142,10 +142,7 @@ describe("CredentialsService", () => {
                 providerName: "github"
             })
 
-            await credentialsService.addMember(
-                _stateId,
-                "code"
-            )
+            await credentialsService.addMember(_stateId, "code")
 
             const fun = credentialsService.setOAuthState({
                 groupId,
@@ -161,10 +158,7 @@ describe("CredentialsService", () => {
 
     describe("# addMember", () => {
         it("Should throw an error if the OAuth does not exist", async () => {
-            const fun = credentialsService.addMember(
-                "123",
-                "code"
-            )
+            const fun = credentialsService.addMember("123", "code")
 
             await expect(fun).rejects.toThrow(`OAuth state does not exist`)
         })
@@ -258,10 +252,7 @@ describe("CredentialsService", () => {
                 providerName: "github"
             })
 
-            const fun = credentialsService.addMember(
-                _stateId,
-                "code"
-            )
+            const fun = credentialsService.addMember(_stateId, "code")
 
             await expect(fun).rejects.toThrow(
                 `OAuth account does not match criteria`
@@ -285,10 +276,7 @@ describe("CredentialsService", () => {
                 providerName: "github"
             })
 
-            const fun = credentialsService.addMember(
-                _stateId,
-                "code"
-            )
+            const fun = credentialsService.addMember(_stateId, "code")
 
             await expect(fun).rejects.toThrow(
                 `OAuth account has already joined the group`

--- a/apps/api/src/app/credentials/credentials.service.ts
+++ b/apps/api/src/app/credentials/credentials.service.ts
@@ -80,10 +80,10 @@ export class CredentialsService {
      * @returns Redirect URI
      */
     async addMember(
-        oAuthCode: string,
         oAuthState: string,
-        address: string,
-        network: string,
+        oAuthCode?: string,
+        address?: string,
+        network?: string,
         blockNumber?: string
     ): Promise<string> {
         if (!this.oAuthState.has(oAuthState)) {

--- a/libs/credentials/src/validators/githubRepositoryCommits/index.ts
+++ b/libs/credentials/src/validators/githubRepositoryCommits/index.ts
@@ -23,10 +23,12 @@ const validator: Validator = {
         if ("profile" in context && context.utils) {
             let allCommits = []
 
+            const [repoOwner, repoName] = criteria.repository.split("/", 2)
+
             for (let i = 0; allCommits.length % 100 === 0; i += 1) {
                 // eslint-disable-next-line no-await-in-loop
                 const commits = await context.utils.api(
-                    `repos/${context.profile.login}/${criteria.repository}/commits?author=${context.profile.login}&per_page=100&page=${i}`
+                    `repos/${repoOwner}/${repoName}/commits?author=${context.profile.login}&per_page=100&page=${i}`
                 )
 
                 if (commits.length === 0) {


### PR DESCRIPTION
## Description

This PR:

- Solves this issue: #378

- Updates parameters in the `addMember` function in the credentials. More context [here](https://github.com/privacy-scaling-explorations/bandada/pull/371#discussion_r1477923532).

## Related Issue

Closes #378

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No


