### PR TITLE
ci: improve ci performance

### DIFF
--- a/.github/workflows/coverall.yml
+++ b/.github/workflows/coverall.yml
@@ -5,9 +5,6 @@ on:
         branches:
             - main
 
-env:
-    DEFAULT_NETWORK: localhost
-
 jobs:
     test:
         runs-on: ubuntu-latest
@@ -18,37 +15,22 @@ jobs:
                     - contracts
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Install Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 18.x
+                  cache: "yarn"
 
-            - name: Get yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-            - name: Restore yarn cache
-              uses: actions/cache@v3
-              id: yarn-cache
-              with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
-
-            - name: Install dependencies
+            - name: Build monorepo
               run: yarn
-
-            - name: Build libraries
-              run: yarn workspaces foreach --no-private run build
 
             - name: Test code
               run: yarn test:${{ matrix.tests }}:coverage
 
             - name: Coveralls
-              uses: coverallsapp/github-action@master
+              uses: coverallsapp/github-action@v2
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   flag-name: run-${{ matrix.tests }}
@@ -60,7 +42,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Coveralls Finished
-              uses: coverallsapp/github-action@master
+              uses: coverallsapp/github-action@v2
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   parallel-finished: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
                   fi
 
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                   persist-credentials: false
 

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -35,7 +35,7 @@ jobs:
                   fi
 
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                   persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,29 +13,19 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
 
+            - uses: actions/checkout@v4
+
             - name: Install Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 18.x
+                  cache: "yarn"
 
-            - name: Get yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-            - name: Restore yarn cache
-              uses: actions/cache@v3
-              id: yarn-cache
-              with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
-
-            - name: Install dependencies
+            - name: Build monorepo
               run: yarn
 
             - run: yarn version:release

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -11,31 +11,16 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Install Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 18.x
+                  cache: "yarn"
 
-            - name: Get yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-            - name: Restore yarn cache
-              uses: actions/cache@v3
-              id: yarn-cache
-              with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
-
-            - name: Install dependencies
+            - name: Build monorepo
               run: yarn
-
-            - name: Build
-              run: yarn build
 
             - name: Run Prettier
               run: yarn prettier

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,39 +6,21 @@ on:
         branches:
             - main
 
-env:
-    DEFAULT_NETWORK: localhost
-
 jobs:
     test:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Install Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 18.x
+                  cache: "yarn"
 
-            - name: Get yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-            - name: Restore yarn cache
-              uses: actions/cache@v3
-              id: yarn-cache
-              with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
-
-            - name: Install dependencies
+            - name: Build monorepo
               run: yarn
-
-            - name: Build libraries
-              run: yarn workspaces foreach --no-private run build
 
             - name: Test code
               run: yarn test


### PR DESCRIPTION
## Description

This PR removes an extra build step since `yarn install` covers all necessary actions, cutting build time by 30 seconds. Also  it phased out `actions/cache` in favor of `actions/setup-node`.

<!--- Describe your changes in detail -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

