### PR TITLE
fix: fix local postgres provisioning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,9 +51,9 @@ services:
         container_name: postgres
         image: postgres
         environment:
-            POSTGRES_USER: root
+            POSTGRES_USER: postgres
             POSTGRES_PASSWORD: helloworld
-            POSTGRES_DB: bandada
+            POSTGRES_DB: postgres
             PGDATA: /data/postgres
         volumes:
             - postgres:/data/postgres


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed an issue where Docker Compose couldn't provision database properly by setting both user and database names to `postgres`


## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Other information

See https://github.com/docker-library/docs/blob/master/postgres/README.md#initialization-scripts

