### PR TITLE
feat: add placeholder to repository input

### DIFF
--- a/apps/dashboard/src/components/new-group-stepper/access-mode-step.tsx
+++ b/apps/dashboard/src/components/new-group-stepper/access-mode-step.tsx
@@ -208,6 +208,11 @@ export default function AccessModeStep({
                                                     }
                                                 })
                                             }
+                                            placeholder={
+                                                parameter[0] === "repository"
+                                                    ? "<repo-owner>/<repo-name>"
+                                                    : undefined
+                                            }
                                         />
                                     )}
                                 </VStack>


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
When creating a credential group in the dashboard, using the Github repository commits credential, there is a field to fill out called Repository where people should write the Github repository owner and name separated by a slash.

The idea is to add a placeholder in the Repository input box. The placeholder would be something like `<repo-owner>/<repo-name>`.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> #385 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

With Changes:
![Screenshot 2024-02-10 at 11 50 57 PM](https://github.com/privacy-scaling-explorations/bandada/assets/60794961/b2c0a742-a784-4a3a-831e-430ec0673998)
