### PR TITLE
feat: a feature that shows that displays the credential id and criteria of an off-chain group

### DIFF
--- a/apps/dashboard/src/pages/group.tsx
+++ b/apps/dashboard/src/pages/group.tsx
@@ -230,6 +230,25 @@ ${memberIds.join("\n")}
     const handleDeselectAll = () => {
         setSelectedMembers([])
     }
+    let credentialsId = ""
+    let credentialsCriteria = ""
+    if (_group && _group.credentials) {
+        const credentialsObj = JSON.parse(_group.credentials)
+        credentialsId = `${credentialsObj.id}`
+
+        if (credentialsObj.criteria) {
+            for (const key in credentialsObj.criteria) {
+                if (
+                    Object.prototype.hasOwnProperty.call(
+                        credentialsObj.criteria,
+                        key
+                    )
+                ) {
+                    credentialsCriteria += `${key}:${credentialsObj.criteria[key]} `
+                }
+            }
+        }
+    }
 
     return _group ? (
         <Container maxW="container.xl" pb="20" px="8">
@@ -349,6 +368,29 @@ ${memberIds.join("\n")}
                         </InputGroup>
                     </Box>
                     )
+                    {groupType === "off-chain" && _group.credentials && (
+                        <Box
+                            bgColor="balticSea.50"
+                            p="25px 30px 25px 30px"
+                            borderRadius="8px"
+                        >
+                            <Text fontSize="20px">Credentials</Text>
+                            <Input
+                                pr="50px"
+                                placeholder="Credentials ID"
+                                mb="10px"
+                                mt="10px"
+                                value={credentialsId}
+                                isDisabled
+                            />
+                            <Input
+                                pr="50px"
+                                placeholder="Credentials Criteria"
+                                value={credentialsCriteria}
+                                isDisabled
+                            />
+                        </Box>
+                    )}
                     {groupType === "off-chain" && !_group.credentials && (
                         <Box
                             bgColor="balticSea.50"


### PR DESCRIPTION


If an off-chain group is credentials group then the ID and critieria is diplayed.This helps in easier management and accessibility/visibility.
This resolves #346 

<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Previously if a group was credential ,there was no mention of it anywhere,it would confuse the user and admin on the credential type(id) and the criteria.This feature Shows the credential id and criteria if it is a credential group.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?


 No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
