### PR TITLE
fix: prevent manual addition of duplicate member IDs in on-chain groups

### DIFF
--- a/apps/dashboard/src/components/add-member-modal.tsx
+++ b/apps/dashboard/src/components/add-member-modal.tsx
@@ -71,6 +71,42 @@ export default function AddMemberModal({
             alert("Please ensure there are no repeated member IDs!")
             return
         }
+        if (group.type === "on-chain" && group.members) {
+            const isHexadecimal = (str: string): boolean =>
+                /^0x[0-9A-Fa-f]+$/i.test(str)
+
+            const existingMembers = new Set(
+                group.members.map((memberId) => {
+                    // Check if member ID is hexadecimal
+                    if (isHexadecimal(memberId)) {
+                        return parseInt(memberId, 16) // Convert hexadecimal to decimal
+                    }
+                    return parseInt(memberId, 10) // Treat as decimal
+                })
+            )
+
+            const conflictingMembers = []
+
+            for (const memberId of memberIds) {
+                // Check if member ID is hexadecimal
+                const parsedMemberId = isHexadecimal(memberId)
+                    ? parseInt(memberId, 16)
+                    : parseInt(memberId, 10)
+
+                if (existingMembers.has(parsedMemberId)) {
+                    conflictingMembers.push(parsedMemberId)
+                }
+            }
+
+            if (conflictingMembers.length > 0) {
+                alert(
+                    `Member IDs ${conflictingMembers.join(
+                        ", "
+                    )} already exist in the group.`
+                )
+                return
+            }
+        }
 
         const confirmMessage = `
 Are you sure you want to add the following members?

--- a/apps/dashboard/src/components/add-member-modal.tsx
+++ b/apps/dashboard/src/components/add-member-modal.tsx
@@ -73,16 +73,13 @@ export default function AddMemberModal({
         }
         if (group.type === "on-chain" && group.members) {
             const existingMembers = new Set(
-                group.members.map((memberId) =>
-                    typeof memberId === "string" ? BigInt(memberId) : memberId
-                )
+                group.members.map((memberId) => BigInt(memberId))
             )
 
             const conflictingMembers = []
 
             for (const memberId of memberIds) {
-                const parsedMemberId =
-                    typeof memberId === "string" ? BigInt(memberId) : memberId
+                const parsedMemberId = BigInt(memberId)
 
                 if (existingMembers.has(parsedMemberId)) {
                     conflictingMembers.push(parsedMemberId)
@@ -90,11 +87,17 @@ export default function AddMemberModal({
             }
 
             if (conflictingMembers.length > 0) {
-                alert(
-                    `Member IDs ${conflictingMembers.join(
-                        ", "
-                    )} already exist in the group.`
-                )
+                if (conflictingMembers.length === 1) {
+                    alert(
+                        `Member ID ${conflictingMembers[0]} already exists in the group.`
+                    )
+                } else {
+                    alert(
+                        `Member IDs ${conflictingMembers.join(
+                            ", "
+                        )} already exist in the group.`
+                    )
+                }
                 return
             }
         }

--- a/apps/dashboard/src/components/add-member-modal.tsx
+++ b/apps/dashboard/src/components/add-member-modal.tsx
@@ -72,26 +72,17 @@ export default function AddMemberModal({
             return
         }
         if (group.type === "on-chain" && group.members) {
-            const isHexadecimal = (str: string): boolean =>
-                /^0x[0-9A-Fa-f]+$/i.test(str)
-
             const existingMembers = new Set(
-                group.members.map((memberId) => {
-                    // Check if member ID is hexadecimal
-                    if (isHexadecimal(memberId)) {
-                        return parseInt(memberId, 16) // Convert hexadecimal to decimal
-                    }
-                    return parseInt(memberId, 10) // Treat as decimal
-                })
+                group.members.map((memberId) =>
+                    typeof memberId === "string" ? BigInt(memberId) : memberId
+                )
             )
 
             const conflictingMembers = []
 
             for (const memberId of memberIds) {
-                // Check if member ID is hexadecimal
-                const parsedMemberId = isHexadecimal(memberId)
-                    ? parseInt(memberId, 16)
-                    : parseInt(memberId, 10)
+                const parsedMemberId =
+                    typeof memberId === "string" ? BigInt(memberId) : memberId
 
                 if (existingMembers.has(parsedMemberId)) {
                     conflictingMembers.push(parsedMemberId)


### PR DESCRIPTION
Previously, on-chain groups did not properly filter duplicate member IDs, allowing the same ID to be added multiple times without restriction. Now, when a user attempts to add an existing member ID to an on-chain group, an alert message  with the exact id/id's is displayed to notify the user and prevent the duplicate addition.

This resolves #302 

<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

Alerting the user when a member id that is already present is added manually .
-Alert message with the exact duplicate id/id's is shown 


Additionally there was another bug that i came across while solving,the user can enter hexa values 
-it is saved in decimal format on the chain
-now another same hexa code can be added ,leads to duplicacy 

-Thus hexa checking is additionally added,it filters and converts to decimal and compares with the stored member id's

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?


-   [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
