### PR TITLE
Add options to `EAS_ATTESTATIONS` credential validator

### DIFF
--- a/libs/credentials/src/types/index.ts
+++ b/libs/credentials/src/types/index.ts
@@ -32,6 +32,9 @@ export type EASContext = {
     queryGraph: (query: string) => Promise<any>
     attester?: BigNumberish
     schemaId?: BigNumberish
+    revocable?: boolean
+    revoked?: boolean
+    isOffchain?: boolean
 }
 
 export type Context = Web2Context | BlockchainContext | EASContext

--- a/libs/credentials/src/validators/easAttestations/index.test.ts
+++ b/libs/credentials/src/validators/easAttestations/index.test.ts
@@ -6,26 +6,50 @@ describe("EASAttestations", () => {
         queryGraph: jest.fn()
     }
 
-    it("Should return true if an account has greater than or equal to 3 attestations", async () => {
-        queryGraphMocked.queryGraph.mockReturnValue([
-            {
-                id: "0x52561c95029d9f2335839ddc96a69ee9737a18e2a781e64659b7bd645ccb8efc",
-                recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8"
-            },
-            {
-                id: "0xee06a022c7d55f67bac213d6b2cd384a899ef79a57f1f5f148e45c313b4fdebe",
-                recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8"
-            },
-            {
-                id: "0xfbc0f1aac4379c18fa9a5b6493825234a8ca82a2a296148465d150c2e64c6202",
-                recipient: "0x0000000000000000000000000000000000000000"
-            },
-            {
-                id: "0x227510204bcfe7b543388b82c6e02aafe7b0d0a20e4f159794e8121611aa601b",
-                recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8"
-            }
-        ])
+    queryGraphMocked.queryGraph.mockReturnValue([
+        {
+            id: "0x52561c95029d9f2335839ddc96a69ee9737a18e2a781e64659b7bd645ccb8efc",
+            recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+            attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
+            revocable: true,
+            revoked: false,
+            schemaId:
+                "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
+            isOffchain: false
+        },
+        {
+            id: "0xee06a022c7d55f67bac213d6b2cd384a899ef79a57f1f5f148e45c313b4fdebe",
+            recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+            attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
+            revocable: true,
+            revoked: false,
+            schemaId:
+                "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
+            isOffchain: false
+        },
+        {
+            id: "0xfbc0f1aac4379c18fa9a5b6493825234a8ca82a2a296148465d150c2e64c6202",
+            recipient: "0x0000000000000000000000000000000000000000",
+            attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
+            revocable: true,
+            revoked: false,
+            schemaId:
+                "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
+            isOffchain: false
+        },
+        {
+            id: "0x227510204bcfe7b543388b82c6e02aafe7b0d0a20e4f159794e8121611aa601b",
+            recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+            attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
+            revocable: true,
+            revoked: false,
+            schemaId:
+                "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
+            isOffchain: false
+        }
+    ])
 
+    it("Should return true if an account has greater than or equal to 3 attestations", async () => {
         const result = await validateCredentials(
             {
                 id: easAttestations.id,
@@ -42,26 +66,145 @@ describe("EASAttestations", () => {
         expect(result).toBeTruthy()
     })
 
-    it("Should return false if an account has less than 3 attestations", async () => {
-        queryGraphMocked.queryGraph.mockReturnValue([
+    it("Should return true if the given optional criterias are satisfied", async () => {
+        const result = await validateCredentials(
             {
-                id: "0x52561c95029d9f2335839ddc96a69ee9737a18e2a781e64659b7bd645ccb8efc",
-                recipient: "0x0000000000000000000000000000000000000000"
+                id: easAttestations.id,
+                criteria: {
+                    minAttestations: 1
+                }
             },
             {
-                id: "0xee06a022c7d55f67bac213d6b2cd384a899ef79a57f1f5f148e45c313b4fdebe",
-                recipient: "0x0000000000000000000000000000000000000000"
-            },
-            {
-                id: "0xfbc0f1aac4379c18fa9a5b6493825234a8ca82a2a296148465d150c2e64c6202",
-                recipient: "0x0000000000000000000000000000000000000000"
-            },
-            {
-                id: "0x227510204bcfe7b543388b82c6e02aafe7b0d0a20e4f159794e8121611aa601b",
-                recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8"
+                recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+                queryGraph: queryGraphMocked.queryGraph,
+                attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
+                schemaId:
+                    "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
+                revocable: true,
+                revoked: false,
+                isOffchain: false
             }
-        ])
+        )
 
+        expect(result).toBeTruthy()
+    })
+
+    it("Should return false if the attester optional criteria doesn't match", async () => {
+        const result = await validateCredentials(
+            {
+                id: easAttestations.id,
+                criteria: {
+                    minAttestations: 1
+                }
+            },
+            {
+                recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+                queryGraph: queryGraphMocked.queryGraph,
+                attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d4",
+                schemaId:
+                    "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
+                revocable: true,
+                revoked: false,
+                isOffchain: false
+            }
+        )
+
+        expect(result).toBeFalsy()
+    })
+
+    it("Should return false if the schemaId optional criteria doesn't match", async () => {
+        const result = await validateCredentials(
+            {
+                id: easAttestations.id,
+                criteria: {
+                    minAttestations: 1
+                }
+            },
+            {
+                recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+                queryGraph: queryGraphMocked.queryGraph,
+                attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
+                schemaId:
+                    "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5d",
+                revocable: true,
+                revoked: false,
+                isOffchain: false
+            }
+        )
+
+        expect(result).toBeFalsy()
+    })
+
+    it("Should return false if the revocable optional criteria doesn't match", async () => {
+        const result = await validateCredentials(
+            {
+                id: easAttestations.id,
+                criteria: {
+                    minAttestations: 1
+                }
+            },
+            {
+                recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+                queryGraph: queryGraphMocked.queryGraph,
+                attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
+                schemaId:
+                    "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
+                revocable: false,
+                revoked: false,
+                isOffchain: false
+            }
+        )
+
+        expect(result).toBeFalsy()
+    })
+
+    it("Should return false if the revoked optional criteria doesn't match", async () => {
+        const result = await validateCredentials(
+            {
+                id: easAttestations.id,
+                criteria: {
+                    minAttestations: 1
+                }
+            },
+            {
+                recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+                queryGraph: queryGraphMocked.queryGraph,
+                attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
+                schemaId:
+                    "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
+                revocable: true,
+                revoked: true,
+                isOffchain: false
+            }
+        )
+
+        expect(result).toBeFalsy()
+    })
+
+    it("Should return false if the isOffchain optional criteria doesn't match", async () => {
+        const result = await validateCredentials(
+            {
+                id: easAttestations.id,
+                criteria: {
+                    minAttestations: 1
+                }
+            },
+            {
+                recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+                queryGraph: queryGraphMocked.queryGraph,
+                attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
+                schemaId:
+                    "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
+                revocable: true,
+                revoked: false,
+                isOffchain: true
+            }
+        )
+
+        expect(result).toBeFalsy()
+    })
+
+    it("Should return false if an account has less than 3 attestations", async () => {
         const result = await validateCredentials(
             {
                 id: easAttestations.id,
@@ -70,7 +213,7 @@ describe("EASAttestations", () => {
                 }
             },
             {
-                recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+                recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae9",
                 queryGraph: queryGraphMocked.queryGraph
             }
         )


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds the `recipient, attester, revocable, revoked, schemaId, isOffchain` options for the `EAS_ATTESTATIONS` credential validator enabling different and richer use-cases.

## Related Issue
closes #401 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
