### PR TITLE
fix(dashboard): hide danger zone & api key sections for non-admins

### DIFF
--- a/apps/dashboard/src/pages/group.tsx
+++ b/apps/dashboard/src/pages/group.tsx
@@ -57,6 +57,13 @@ export default function GroupPage(): JSX.Element {
     const [_removeGroupName, setRemoveGroupName] = useState<string>("")
     const [_selectedMembers, setSelectedMembers] = useState<string[]>([])
     const { admin } = useContext(AuthContext)
+    const isGroupAdmin = !!(
+        admin &&
+        _group &&
+        (groupType === "off-chain"
+            ? _group.admin === admin.id
+            : _group.admin === admin.address.toLowerCase())
+    )
 
     useEffect(() => {
         ;(async () => {
@@ -349,82 +356,87 @@ ${memberIds.join("\n")}
                         </InputGroup>
                     </Box>
                     )
-                    {groupType === "off-chain" && !_group.credentials && (
-                        <Box
-                            bgColor="balticSea.50"
-                            p="25px 30px 25px 30px"
-                            borderRadius="8px"
-                        >
-                            <HStack justify="space-between">
-                                <Text fontSize="20px">Use API key</Text>
+                    {groupType === "off-chain" &&
+                        !_group.credentials &&
+                        isGroupAdmin && (
+                            <Box
+                                bgColor="balticSea.50"
+                                p="25px 30px 25px 30px"
+                                borderRadius="8px"
+                            >
+                                <HStack justify="space-between">
+                                    <Text fontSize="20px">Use API key</Text>
 
-                                <Switch
-                                    id="enable-api"
-                                    isChecked={_group.apiEnabled}
-                                    onChange={(event) =>
-                                        onApiAccessToggle(event.target.checked)
-                                    }
-                                />
-                            </HStack>
+                                    <Switch
+                                        id="enable-api"
+                                        isChecked={_group.apiEnabled}
+                                        onChange={(event) =>
+                                            onApiAccessToggle(
+                                                event.target.checked
+                                            )
+                                        }
+                                    />
+                                </HStack>
 
-                            <Text mt="10px" color="balticSea.700">
-                                Connect your app to your group using an API key.
-                            </Text>
+                                <Text mt="10px" color="balticSea.700">
+                                    Connect your app to your group using an API
+                                    key.
+                                </Text>
 
-                            {_group.apiEnabled && (
-                                <>
-                                    <InputGroup size="lg" mt="10px">
-                                        <Input
-                                            pr="50px"
-                                            placeholder="API key"
-                                            value={_group?.apiKey}
-                                            isDisabled
-                                        />
+                                {_group.apiEnabled && (
+                                    <>
+                                        <InputGroup size="lg" mt="10px">
+                                            <Input
+                                                pr="50px"
+                                                placeholder="API key"
+                                                value={_group?.apiKey}
+                                                isDisabled
+                                            />
 
-                                        <InputRightElement mr="5px">
-                                            <Tooltip
-                                                label={
-                                                    hasCopied
-                                                        ? "Copied!"
-                                                        : "Copy"
-                                                }
-                                                closeOnClick={false}
-                                                hasArrow
-                                            >
-                                                <IconButton
-                                                    variant="link"
-                                                    aria-label="Copy API key"
-                                                    onClick={onCopy}
-                                                    onMouseDown={(e) =>
-                                                        e.preventDefault()
+                                            <InputRightElement mr="5px">
+                                                <Tooltip
+                                                    label={
+                                                        hasCopied
+                                                            ? "Copied!"
+                                                            : "Copy"
                                                     }
-                                                    icon={
-                                                        <Icon
-                                                            color="sunsetOrange.600"
-                                                            boxSize="5"
-                                                            as={FiCopy}
-                                                        />
-                                                    }
-                                                />
-                                            </Tooltip>
-                                        </InputRightElement>
-                                    </InputGroup>
+                                                    closeOnClick={false}
+                                                    hasArrow
+                                                >
+                                                    <IconButton
+                                                        variant="link"
+                                                        aria-label="Copy API key"
+                                                        onClick={onCopy}
+                                                        onMouseDown={(e) =>
+                                                            e.preventDefault()
+                                                        }
+                                                        icon={
+                                                            <Icon
+                                                                color="sunsetOrange.600"
+                                                                boxSize="5"
+                                                                as={FiCopy}
+                                                            />
+                                                        }
+                                                    />
+                                                </Tooltip>
+                                            </InputRightElement>
+                                        </InputGroup>
 
-                                    <Button
-                                        mt="10px"
-                                        variant="link"
-                                        color="balticSea.600"
-                                        textDecoration="underline"
-                                        onClick={generateApiKey}
-                                    >
-                                        Generate new key
-                                    </Button>
-                                </>
-                            )}
-                        </Box>
-                    )}
+                                        <Button
+                                            mt="10px"
+                                            variant="link"
+                                            color="balticSea.600"
+                                            textDecoration="underline"
+                                            onClick={generateApiKey}
+                                        >
+                                            Generate new key
+                                        </Button>
+                                    </>
+                                )}
+                            </Box>
+                        )}
                     <Image src={image1} />
-                    {_group.type === "off-chain" && (
+                    {_group.type === "off-chain" && isGroupAdmin && (
                         <Box
                             bgColor="classicRose.50"
                             p="25px 30px 25px 30px"
@@ -482,13 +494,7 @@ ${memberIds.join("\n")}
                             variant="solid"
                             colorScheme="secondary"
                             onClick={addMembersModal.onOpen}
-                            hidden={
-                                !admin ||
-                                (groupType === "off-chain"
-                                    ? _group.admin !== admin.id
-                                    : _group.admin !==
-                                      admin.address.toLowerCase())
-                            }
+                            hidden={!isGroupAdmin}
                         >
                             Add member
                         </Button>


### PR DESCRIPTION
## Description

Created an `isGroupAdmin` var to hide the "Danger Zone" & "Use API Key" sections on the group page for non-admins. Also, refactored the "Add member" button to use this newly created var for hiding.

## Related Issue

- #306
- #307

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Screenshots

|Before|After|
|--|--|
|![](https://github.com/privacy-scaling-explorations/bandada/assets/12480362/4efab62c-1f41-4305-9010-931ee096b479)|![](https://github.com/privacy-scaling-explorations/bandada/assets/12480362/c1d91e76-ff97-4d13-b320-35c8b85fcfa5)|