### PR TITLE
fix(dashboard): hide member edit actions for non-admins

### DIFF
--- a/apps/dashboard/src/pages/group.tsx
+++ b/apps/dashboard/src/pages/group.tsx
@@ -543,18 +543,19 @@ ${memberIds.join("\n")}
                             >
                                 <HStack justify="space-between" w="100%">
                                     <HStack>
-                                        {_group.type === "off-chain" && isGroupAdmin && (
-                                            <Checkbox
-                                                isChecked={_selectedMembers.includes(
-                                                    memberId
-                                                )}
-                                                onChange={() =>
-                                                    toggleMemberSelection(
+                                        {_group.type === "off-chain" &&
+                                            isGroupAdmin && (
+                                                <Checkbox
+                                                    isChecked={_selectedMembers.includes(
                                                         memberId
-                                                    )
-                                                }
-                                            />
-                                        )}
+                                                    )}
+                                                    onChange={() =>
+                                                        toggleMemberSelection(
+                                                            memberId
+                                                        )
+                                                    }
+                                                />
+                                            )}
                                         <Icon
                                             color="balticSea.300"
                                             boxSize="6"
@@ -568,39 +569,46 @@ ${memberIds.join("\n")}
                                         </Text>
                                     </HStack>
 
-                                    {_group.type === "off-chain" && isGroupAdmin && (
-                                        <Menu>
-                                            <MenuButton
-                                                as={IconButton}
-                                                aria-label="Options"
-                                                icon={
-                                                    <Icon
-                                                        color="balticSea.300"
-                                                        boxSize="6"
-                                                        as={MdOutlineMoreVert}
-                                                    />
-                                                }
-                                                variant="link"
-                                            />
-                                            <MenuList>
-                                                <MenuItem
+                                    {_group.type === "off-chain" &&
+                                        isGroupAdmin && (
+                                            <Menu>
+                                                <MenuButton
+                                                    as={IconButton}
+                                                    aria-label="Options"
                                                     icon={
                                                         <Icon
-                                                            mt="5px"
                                                             color="balticSea.300"
                                                             boxSize="6"
-                                                            as={MdOutlineCancel}
+                                                            as={
+                                                                MdOutlineMoreVert
+                                                            }
                                                         />
                                                     }
-                                                    onClick={() =>
-                                                        removeMember(memberId)
-                                                    }
-                                                >
-                                                    Remove
-                                                </MenuItem>
-                                            </MenuList>
-                                        </Menu>
-                                    )}
+                                                    variant="link"
+                                                />
+                                                <MenuList>
+                                                    <MenuItem
+                                                        icon={
+                                                            <Icon
+                                                                mt="5px"
+                                                                color="balticSea.300"
+                                                                boxSize="6"
+                                                                as={
+                                                                    MdOutlineCancel
+                                                                }
+                                                            />
+                                                        }
+                                                        onClick={() =>
+                                                            removeMember(
+                                                                memberId
+                                                            )
+                                                        }
+                                                    >
+                                                        Remove
+                                                    </MenuItem>
+                                                </MenuList>
+                                            </Menu>
+                                        )}
                                 </HStack>
                             </Flex>
                         ))

--- a/apps/dashboard/src/pages/group.tsx
+++ b/apps/dashboard/src/pages/group.tsx
@@ -543,7 +543,7 @@ ${memberIds.join("\n")}
                             >
                                 <HStack justify="space-between" w="100%">
                                     <HStack>
-                                        {_group.type === "off-chain" && (
+                                        {_group.type === "off-chain" && isGroupAdmin && (
                                             <Checkbox
                                                 isChecked={_selectedMembers.includes(
                                                     memberId
@@ -568,7 +568,7 @@ ${memberIds.join("\n")}
                                         </Text>
                                     </HStack>
 
-                                    {_group.type === "off-chain" && (
+                                    {_group.type === "off-chain" && isGroupAdmin && (
                                         <Menu>
                                             <MenuButton
                                                 as={IconButton}
@@ -605,7 +605,7 @@ ${memberIds.join("\n")}
                             </Flex>
                         ))
                     )}
-                    {_group.type === "off-chain" && (
+                    {_group.type === "off-chain" && isGroupAdmin && (
                         <Flex mt="20px" justify="space-between" align="center">
                             <ButtonGroup>
                                 <Button


### PR DESCRIPTION
## Description

Hides the member edit actions from the UI for non-admins. Same method as used in #413.

## Related Issue

- #415

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Screenshots

|Before|After|
|---|---|
|![](https://github.com/privacy-scaling-explorations/bandada/assets/12480362/fc73143c-cbe4-47b5-bf05-b8c5aa476d98)|![](https://github.com/privacy-scaling-explorations/bandada/assets/12480362/55044353-8ac4-41f8-bb4e-9c7a1a9b1b0c)|