### PR TITLE
fix: Fix network name variable in index.ts

### DIFF
--- a/libs/credentials/src/types/index.ts
+++ b/libs/credentials/src/types/index.ts
@@ -4,7 +4,7 @@ export enum EASNetworks {
     ETHEREUM = "ethereum",
     ETHEREUM_SEPOLIA = "sepolia",
     ARBITRUM = "arbitrum",
-    ARIBITRUM_NOVA = "arbitrum-nova",
+    ARBITRUM_NOVA = "arbitrum-nova",
     BASE = "base",
     BASE_SEPOLIA = "base-sepolia",
     LINEA = "linea",


### PR DESCRIPTION
## Description

I’ve fixed a error in the `EASNetworks` by correcting the variable `ARIBITRUM_NOVA` to `ARBITRUM_NOVA` (with a single “I”), which resolves the issue with the "Arbitrum Nova" network name.

<img width="327" alt="Снимок экрана 2025-01-31 в 20 26 43" src="https://github.com/user-attachments/assets/436954c0-53cd-4bca-91cc-964c9e3ceaab" />


## Checklist

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

